### PR TITLE
fix compilation errors and memory leak

### DIFF
--- a/Advance C++/001 MyVector/MyVector.h
+++ b/Advance C++/001 MyVector/MyVector.h
@@ -4,6 +4,8 @@
 #include <new>
 #include <stdio.h>
 #include <cassert>
+#include <utility> // std::move
+#include <cstring> // memcpy
 
 class NonCopyable {
 public:
@@ -201,7 +203,7 @@ class MyVector : public MyIVector<T>, public LocalBuf<T, LOCAL_BUF_SIZE> {
 	using BUF = LocalBuf<T, LOCAL_BUF_SIZE>;
 public:
 	virtual ~MyVector() {
-		clearAndFree();
+		this->clearAndFree();
 	}
 
 protected:
@@ -219,7 +221,7 @@ protected:
 		}
 	}
 
-	virtual bool isUsingLocalBuf() const { return localBuf() == data(); }
+	virtual bool isUsingLocalBuf() const { return this->localBuf() == this->data(); }
 };
 
 template<typename T>
@@ -317,6 +319,7 @@ void MyIVector<T>::reserve(int n)
 					src->~T();
 				}
 			}
+      onFree(m_data);
 		} catch (...) {
 			onFree(newData);
 			throw;

--- a/Advance C++/001 MyVector/main.cpp
+++ b/Advance C++/001 MyVector/main.cpp
@@ -1,8 +1,11 @@
 #include "MyVector.h"
 #include "MyArray.h"
-#include <conio.h>
 #include <stdio.h>
 #include <vector>
+
+#ifdef _WIN32
+#include <conio.h>
+#endif
 
 class MyColor {
 	float r,g,b,a;
@@ -127,6 +130,9 @@ int main() {
 	test004();
 
 	printf("\n====== Program Ended =========\n");
+
+#ifdef _WIN32
 	_getch();
+#endif
 	return 0;
 }


### PR DESCRIPTION
## Fixes memory leaks detected and Resolve Compilation Errors

### Problem 1: Memory Leak Detected by AddressSanitizer
```bash
$ g++ -fsanitize=address -o app.out main.cpp
./app.out
```

```bash
MyVector<int> size = 16, cap = 16
 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0


====== Program Ended =========

=================================================================
==397738==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x75f189afd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x60da0d754067 in MyVector<int, 0>::onMalloc(int) (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x9067) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #2 0x60da0d750523 in MyIVector<int>::reserve(int) (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x5523) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #3 0x60da0d74fb50 in void MyIVector<int>::resize<>(int) (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x4b50) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #4 0x60da0d74e185 in test004() (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x3185) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #5 0x60da0d74e3b0 in main (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x33b0) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #6 0x75f18922a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x75f18922a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #8 0x60da0d74d504 in _start (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x2504) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x75f189afd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x60da0d754067 in MyVector<int, 0>::onMalloc(int) (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x9067) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #2 0x60da0d750523 in MyIVector<int>::reserve(int) (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x5523) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #3 0x60da0d74fb50 in void MyIVector<int>::resize<>(int) (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x4b50) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #4 0x60da0d74e173 in test004() (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x3173) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #5 0x60da0d74e3b0 in main (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x33b0) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)
    #6 0x75f18922a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x75f18922a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #8 0x60da0d74d504 in _start (/home/gapry/Workspaces/SimpleTalkCpp_Tutorial/Advance C++/001 MyVector/app.out+0x2504) (BuildId: 92a68ded3394342a7343de77b33275bb82e0c840)

SUMMARY: AddressSanitizer: 20 byte(s) leaked in 2 allocation(s).
```

#### Cause:
When allocating a new buffer in `reserve()`, the old buffer `m_data` was not properly freed after copying data to the new allocation.

#### Fix:
Added the missing `onFree(m_data)` call after data transfer to `newData` to properly manage memory.

#### Change:
```cpp
auto* src = m_data;
auto* end = m_data + m_size;
auto* dst = newData;

if (isRawCopyable<T>::value) {
  memcpy(dst, src, sizeof(T) * m_size);
} else {
  for (; src < end; src++, dst++) {
    new(dst) T(std::move(*src)); //placement new
    src->~T();
  }
}
onFree(m_data); // <-- add here
```

### Problem 2: Compilation errors
```bash
$ g++ -fsanitize=address -o app.out main.cpp
In file included from main.cpp:1:
MyVector.h: In destructor ‘virtual MyVector<T, LOCAL_BUF_SIZE>::~MyVector()’:
MyVector.h:206:17: error: there are no arguments to ‘clearAndFree’ that depend on a template parameter, so a declaration of ‘clearAndFree’ must be available [-fpermissive]
  206 |                 clearAndFree();
      |                 ^~~~~~~~~~~~
MyVector.h:206:17: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
MyVector.h: In member function ‘virtual bool MyVector<T, LOCAL_BUF_SIZE>::isUsingLocalBuf() const’:
MyVector.h:224:55: error: there are no arguments to ‘localBuf’ that depend on a template parameter, so a declaration of ‘localBuf’ must be available [-fpermissive]
  224 |         virtual bool isUsingLocalBuf() const { return localBuf() == data(); }
      |                                                       ^~~~~~~~
MyVector.h:224:69: error: there are no arguments to ‘data’ that depend on a template parameter, so a declaration of ‘data’ must be available [-fpermissive]
  224 |         virtual bool isUsingLocalBuf() const { return localBuf() == data(); }
```

#### Fix:
Adding the `this->` prefix ensures that these function calls are correctly resolved because the compiler does not search for names in dependent base classes until template instantiation. Explicit qualification (`this->`) is required to make them visible.

To resolve the other compilation error, simply add the missing included files and define `_WIN32` where necessary.